### PR TITLE
Run plugin verification against intellij community and goland

### DIFF
--- a/witchcraft-logging-idea/build.gradle
+++ b/witchcraft-logging-idea/build.gradle
@@ -49,7 +49,15 @@ publishPlugin {
     token = System.env.JETBRAINS_PLUGIN_REPO_TOKEN
 }
 
-check.dependsOn buildPlugin, verifyPlugin
+runPluginVerifier {
+    ideVersions = [
+            // Idea Community
+            "IC-2021.2",
+            // Goland
+            "GO-2021.2"]
+}
+
+check.dependsOn buildPlugin, verifyPlugin, runPluginVerifier
 tasks.publishPlugin.onlyIf { versionDetails().isCleanTag && System.env.JETBRAINS_PLUGIN_REPO_TOKEN != null }
 tasks.publish.dependsOn publishPlugin
 buildSearchableOptions.enabled = false


### PR DESCRIPTION
Should provide more confidence in our builds. Everything seems to work.

==COMMIT_MSG==
Run plugin verification against intellij community and goland
==COMMIT_MSG==
