### PR TITLE
`request.2` log formatting uses `unsafeParams.path` when available

### DIFF
--- a/changelog/@unreleased/pr-3.v2.yml
+++ b/changelog/@unreleased/pr-3.v2.yml
@@ -1,0 +1,7 @@
+type: improvement
+improvement:
+  description: '`request.2` log formatting uses `unsafeParams.path` when available.
+    This allows us to debug tests more easily when clients are misconfigured, for
+    example with an incorrect context-path.'
+  links:
+  - https://github.com/palantir/witchcraft-java-logging/pull/3

--- a/witchcraft-logging-formatting/src/main/java/com/palantir/witchcraft/java/logging/format/RequestLogFormatter.java
+++ b/witchcraft-logging-formatting/src/main/java/com/palantir/witchcraft/java/logging/format/RequestLogFormatter.java
@@ -26,7 +26,7 @@ final class RequestLogFormatter {
 
     private static final Pattern REQUEST_PARAMETER_PATTERN = Pattern.compile("\\{(\\S+?)}");
     // Common implementations often store the raw unsafe path in 'unsafeParams.path'.
-    // We can use that path when present for a better debugging expereience, especially
+    // We can use that path when present for a better debugging experience, especially
     // in cases tests fail due to unmatched paths where we'd otherwise see '/*'
     // or '(unmatched path)'
     private static final String UNSAFE_PATH_PARAMETER = "path";

--- a/witchcraft-logging-formatting/src/test/java/com/palantir/witchcraft/java/logging/format/RequestLogFormatterTest.java
+++ b/witchcraft-logging-formatting/src/test/java/com/palantir/witchcraft/java/logging/format/RequestLogFormatterTest.java
@@ -40,4 +40,40 @@ class RequestLogFormatterTest {
 
         assertThat(formatted).isEqualTo("[2019-12-25T01:02:03Z] \"GET /some/path/value http\" 203 40 99");
     }
+
+    @Test
+    void prefers_unsafe_path() {
+        String formatted = RequestLogFormatter.format(RequestLogV2.builder()
+                .type("request.1")
+                .time(TestData.XMAS_2019)
+                .protocol("http")
+                .path("/some/path/{unknown}")
+                .status(203)
+                .requestSize(SafeLong.of(20))
+                .responseSize(SafeLong.of(40))
+                .duration(SafeLong.of(99))
+                .method("GET")
+                .unsafeParams("path", "/some/path/value")
+                .build());
+
+        assertThat(formatted).isEqualTo("[2019-12-25T01:02:03Z] \"GET /some/path/value http\" 203 40 99");
+    }
+
+    @Test
+    void ignores_bogus_unsafe_path() {
+        String formatted = RequestLogFormatter.format(RequestLogV2.builder()
+                .type("request.1")
+                .time(TestData.XMAS_2019)
+                .protocol("http")
+                .path("/some/path/{unknown}")
+                .status(203)
+                .requestSize(SafeLong.of(20))
+                .responseSize(SafeLong.of(40))
+                .duration(SafeLong.of(99))
+                .method("GET")
+                .unsafeParams("path", ":witchcraft-logging-formatting")
+                .build());
+
+        assertThat(formatted).isEqualTo("[2019-12-25T01:02:03Z] \"GET /some/path/{unknown} http\" 203 40 99");
+    }
 }


### PR DESCRIPTION
This allows us to debug tests more easily when clients are
misconfigured, for example with an incorrect context-path.

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
==COMMIT_MSG==
`request.2` log formatting uses `unsafeParams.path` when available. This allows us to debug tests more easily when clients are misconfigured, for example with an incorrect context-path.
==COMMIT_MSG==

## Possible downsides?
Possible an unsafe `path` attribute could be associated with the request. If it's an absolute file path, it may pass our simple predicate. This is fairly unlikely, and test failures due to incorrect prefixes are a common waste of developer time.