### PR TITLE
Service log formatting quality of life improvements

### DIFF
--- a/changelog/@unreleased/pr-5.v2.yml
+++ b/changelog/@unreleased/pr-5.v2.yml
@@ -1,0 +1,15 @@
+type: improvement
+improvement:
+  description: |-
+    Service log formatting quality of life improvements.
+    * Parameters which are interpolated into the formatted output are
+    no longer included in the trailing key/value parameter pairs, for
+    more concise output.
+    * Parameters are automatically interpolated into the stackTrace
+    field, unsafe throwable messages are easier to follow in a
+    development environment.
+    * Service log lines include the thread name on which events were
+    created, previously this data was not included in the formatted
+    output.
+  links:
+  - https://github.com/palantir/witchcraft-java-logging/pull/5

--- a/witchcraft-logging-formatting/src/main/java/com/palantir/witchcraft/java/logging/format/ServiceLogFormatter.java
+++ b/witchcraft-logging-formatting/src/main/java/com/palantir/witchcraft/java/logging/format/ServiceLogFormatter.java
@@ -16,12 +16,21 @@
 
 package com.palantir.witchcraft.java.logging.format;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 import com.palantir.witchcraft.api.logging.ServiceLogV1;
 import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.slf4j.helpers.MessageFormatter;
 
 final class ServiceLogFormatter {
+    private static final Pattern PARAMETER_PATTERN = Pattern.compile("\\{(\\S+?)}");
+
     private ServiceLogFormatter() {}
 
     static String format(ServiceLogV1 service) {
@@ -30,37 +39,48 @@ final class ServiceLogFormatter {
             while (buffer.length() < 6) {
                 buffer.append(' ');
             }
+            Map<String, Object> mergedParameters = new LinkedHashMap<>(
+                    service.getParams().size() + service.getUnsafeParams().size());
+            mergedParameters.putAll(service.getParams());
+            mergedParameters.putAll(service.getUnsafeParams());
             buffer.append('[');
             DateTimeFormatter.ISO_INSTANT.formatTo(service.getTime(), buffer);
-            buffer.append("] ")
-                    .append(service.getOrigin().orElse("<nil>"))
+            buffer.append("] ");
+            Optional<String> maybeThread = service.getThread();
+            if (maybeThread.isPresent()) {
+                buffer.append('[').append(maybeThread.get()).append("] ");
+            }
+            buffer.append(service.getOrigin().orElse("<nil>"))
                     .append(": ")
-                    .append(getMessage(service));
-            if (!service.getParams().isEmpty() || !service.getUnsafeParams().isEmpty()) {
+                    .append(getMessage(service.getMessage(), mergedParameters));
+            Optional<String> maybeStackTrace = getStackTrace(service, mergedParameters);
+            if (!mergedParameters.isEmpty()) {
                 buffer.append(" (");
-                Formatting.formatParamsTo(service.getParams(), buffer);
-                Formatting.formatParamsTo(service.getUnsafeParams(), buffer);
+                Formatting.formatParamsTo(mergedParameters, buffer);
                 // Reset trailing separator
                 buffer.setLength(buffer.length() - 2);
                 buffer.append(')');
             }
-            service.getStacktrace()
-                    .map(input -> Strings.emptyToNull(Formatting.NEWLINE_MATCHER.trimFrom(input)))
-                    .ifPresent(stackTrace -> buffer.append('\n').append(stackTrace));
+            maybeStackTrace.ifPresent(stackTrace -> buffer.append('\n').append(stackTrace));
         });
     }
 
-    private static String getMessage(ServiceLogV1 service) {
-        String formatString = service.getMessage();
+    private static Optional<String> getStackTrace(
+            ServiceLogV1 service, /* mutable */ Map<String, Object> mergedParameters) {
+        return service.getStacktrace()
+                .map(input -> Strings.emptyToNull(Formatting.NEWLINE_MATCHER.trimFrom(input)))
+                .map(input -> interpolateParameters(input, mergedParameters::remove));
+    }
+
+    private static String getMessage(String formatString, /* mutable */ Map<String, Object> mergedParameters) {
         // If placeholders are found, attempt slf4j-style interpolation
         int placeholders = countPlaceholders(formatString);
         if (placeholders > 0) {
             Object[] parameters = new Object[placeholders];
             for (int i = 0; i < placeholders; i++) {
-                parameters[i] = service.getUnsafeParams()
-                        // Use the placeholder string by default to avoid modifying non-existent parameters.
-                        // This can occur if only some parameters are wrapped with log-safe args.
-                        .getOrDefault("" + i, "{}");
+                // Use the placeholder string by default to avoid modifying non-existent parameters.
+                // This can occur if only some parameters are wrapped with log-safe args.
+                parameters[i] = MoreObjects.firstNonNull(mergedParameters.remove("" + i), "{}");
             }
             // Use the slf4j provided utility directly
             return MessageFormatter.arrayFormat(formatString, parameters).getMessage();
@@ -76,5 +96,18 @@ final class ServiceLogFormatter {
             }
         }
         return count;
+    }
+
+    private static String interpolateParameters(String original, Function<String, Object> lookup) {
+        Matcher matcher = PARAMETER_PATTERN.matcher(original);
+        String current = original;
+        while (matcher.find()) {
+            String name = matcher.group(1);
+            Object value = lookup.apply(name);
+            if (value != null) {
+                current = current.replace("{" + name + "}", Formatting.safeString(value));
+            }
+        }
+        return current;
     }
 }

--- a/witchcraft-logging-formatting/src/test/java/com/palantir/witchcraft/java/logging/format/ServiceLogFormatterTest.java
+++ b/witchcraft-logging-formatting/src/test/java/com/palantir/witchcraft/java/logging/format/ServiceLogFormatterTest.java
@@ -38,9 +38,8 @@ class ServiceLogFormatterTest {
                 .build());
 
         assertThat(formatted)
-                .isEqualTo(
-                        "INFO  [2019-12-25T01:02:03Z] com.origin: message {} (param1: value1, unsafeParam2: value2)\n"
-                                + "java.lang.Exception: stacktrace");
+                .isEqualTo("INFO  [2019-12-25T01:02:03Z] [thread-1] com.origin: message {} (param1: value1, "
+                        + "unsafeParam2: value2)\njava.lang.Exception: stacktrace");
     }
 
     @Test
@@ -54,7 +53,24 @@ class ServiceLogFormatterTest {
                 .unsafeParams("0", "inlined")
                 .build());
 
+        assertThat(formatted).isEqualTo("ERROR [2019-12-25T01:02:03Z] <nil>: message inlined (param: value)");
+    }
+
+    @Test
+    void interpolates_stack_trace_parameters() {
+        String formatted = ServiceLogFormatter.format(ServiceLogV1.builder()
+                .type("service.1")
+                .level(LogLevel.INFO)
+                .time(TestData.XMAS_2019)
+                .message("message")
+                .origin("com.origin")
+                .thread("thread-1")
+                .unsafeParams("throwable0_message", "exception message")
+                .stacktrace("java.lang.Exception: {throwable0_message}")
+                .build());
+
         assertThat(formatted)
-                .isEqualTo("ERROR [2019-12-25T01:02:03Z] <nil>: message inlined (param: value, 0: inlined)");
+                .isEqualTo("INFO  [2019-12-25T01:02:03Z] [thread-1] com.origin: message\n"
+                        + "java.lang.Exception: exception message");
     }
 }

--- a/witchcraft-logging-idea/src/test/java/com/palantir/witchcraft/java/logging/idea/WitchcraftLogFormatFilterTest.java
+++ b/witchcraft-logging-idea/src/test/java/com/palantir/witchcraft/java/logging/idea/WitchcraftLogFormatFilterTest.java
@@ -39,7 +39,8 @@ public final class WitchcraftLogFormatFilterTest {
             + "\"time\":\"2019-05-09T15:32:37.692Z\",\"origin\":\"ROOT\","
             + "\"thread\":\"main\",\"message\":\"test good {}\","
             + "\"params\":{\"good\":\":-)\"},\"unsafeParams\":{},\"tags\":{}}";
-    private static final String SERVICE_FORMATTED = "ERROR [2019-05-09T15:32:37.692Z] ROOT: test good {} (good: :-))";
+    private static final String SERVICE_FORMATTED =
+            "ERROR [2019-05-09T15:32:37.692Z] [main] ROOT: test good {} (good: :-))";
 
     private static final String REQUEST_JSON = "{\"type\":\"request.2\",\"time\":\"2019-05-24T12:40:36.703-04:00\","
             + "\"method\":\"GET\",\"protocol\":\"HTTP/1.1\",\"path\":\"/api/sleep/{millis}\","
@@ -107,7 +108,7 @@ public final class WitchcraftLogFormatFilterTest {
                         + "\"time\":\"2019-05-09T15:32:37.692Z\",\"origin\":\"ROOT\","
                         + "\"thread\":\"main\",\"message\":\"Hello, {}!\","
                         + "\"params\":{},\"unsafeParams\":{\"0\": \"World\"},\"tags\":{}}"))
-                .isEqualTo("ERROR [2019-05-09T15:32:37.692Z] ROOT: Hello, World! (0: World)");
+                .isEqualTo("ERROR [2019-05-09T15:32:37.692Z] [main] ROOT: Hello, World!");
     }
 
     @Test


### PR DESCRIPTION
```diff
- ERROR [2019-05-09T15:32:37.692Z] ROOT: Hello, World! (0: World)
+ ERROR [2019-05-09T15:32:37.692Z] [main] ROOT: Hello, World!
```

==COMMIT_MSG==
Service log formatting quality of life improvements.
* Parameters which are interpolated into the formatted output are
no longer included in the trailing key/value parameter pairs, for
more concise output.
* Parameters are automatically interpolated into the stackTrace
field, unsafe throwable messages are easier to follow in a
development environment.
* Service log lines include the thread name on which events were
created, previously this data was not included in the formatted
output.

==COMMIT_MSG==
