### PR TITLE
Reduce minimum intellij supported version to 2020.3

### DIFF
--- a/changelog/@unreleased/pr-8.v2.yml
+++ b/changelog/@unreleased/pr-8.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Reduce minimum intellij supported version to 2020.3
+  links:
+  - https://github.com/palantir/witchcraft-java-logging/pull/8

--- a/witchcraft-logging-idea/build.gradle
+++ b/witchcraft-logging-idea/build.gradle
@@ -33,7 +33,7 @@ versionsLock {
     disableJavaPluginDefaults()
 }
 
-def minimumIntellijBuild = '211.7628.21' // 2021.1.3
+def minimumIntellijBuild = '203.6682.168' // 2020.3.1
 intellij {
     pluginName = 'witchcraft-logging-idea'
     version = minimumIntellijBuild
@@ -53,6 +53,8 @@ runPluginVerifier {
     ideVersions = [
             // Idea Community
             "IC-2021.2",
+            // Idea Ultimate
+            "IU-2020.3.1",
             // Goland
             "GO-2021.2"]
 }


### PR DESCRIPTION
Many users are sitting on 2020.3 to due bugs introduced in later
versions. We believe most of them have been resolved, however
folks tend to upgrade IDEs relatively slowly.

==COMMIT_MSG==
Reduce minimum intellij supported version to 2020.3
==COMMIT_MSG==