### PR TITLE
Intellij plugin formats objects which include unknown fields

### DIFF
--- a/changelog/@unreleased/pr-11.v2.yml
+++ b/changelog/@unreleased/pr-11.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Intellij plugin formats objects which include unknown fields. Previously
+    new fields added to existing types resulted in raw json console lines.
+  links:
+  - https://github.com/palantir/witchcraft-java-logging/pull/11

--- a/witchcraft-logging-formatting/src/main/java/com/palantir/witchcraft/java/logging/format/LogParser.java
+++ b/witchcraft-logging-formatting/src/main/java/com/palantir/witchcraft/java/logging/format/LogParser.java
@@ -61,7 +61,8 @@ public final class LogParser<T> {
             .registerModule(new Jdk8Module().configureAbsentsAsNulls(true))
             .registerModule(new JavaTimeModule())
             .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
-            .disable(DeserializationFeature.WRAP_EXCEPTIONS);
+            .disable(DeserializationFeature.WRAP_EXCEPTIONS)
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
     private final LogVisitor<T> logVisitor;
     private final WrappedLogDelegatingVisitor<T> wrappedLogDelegatingVisitor;

--- a/witchcraft-logging-formatting/src/test/java/com/palantir/witchcraft/java/logging/format/LogParserTest.java
+++ b/witchcraft-logging-formatting/src/test/java/com/palantir/witchcraft/java/logging/format/LogParserTest.java
@@ -32,6 +32,11 @@ class LogParserTest {
             + "\"thread\":\"main\",\"message\":\"test good {}\","
             + "\"params\":{\"good\":\":-)\"},\"unsafeParams\":{},\"tags\":{}}";
 
+    private static final String SERVICE_JSON_WITH_UNKNOWN_FIELD = "{\"type\":\"service.1\",\"level\":\"ERROR\","
+            + "\"time\":\"2019-05-09T15:32:37.692Z\",\"origin\":\"ROOT\","
+            + "\"thread\":\"main\",\"message\":\"test good {}\","
+            + "\"params\":{\"good\":\":-)\"},\"unsafeParams\":{},\"unknownField\":\"value\"}";
+
     private static final String REQUEST_JSON = "{\"type\":\"request.2\",\"time\":\"2019-05-24T12:40:36.703-04:00\","
             + "\"method\":\"GET\",\"protocol\":\"HTTP/1.1\",\"path\":\"/api/sleep/{millis}\","
             + "\"params\":{\"host\":\"localhost:8443\",\"connection\":\"Keep-Alive\","
@@ -108,6 +113,11 @@ class LogParserTest {
     @Test
     void parse_service_logs() {
         assertThat(logParser.tryParse(SERVICE_JSON)).hasValue("serviceV1");
+    }
+
+    @Test
+    void parse_service_logs_with_unknown_field() {
+        assertThat(logParser.tryParse(SERVICE_JSON_WITH_UNKNOWN_FIELD)).hasValue("serviceV1");
     }
 
     @Test

--- a/witchcraft-logging-idea/src/test/java/com/palantir/witchcraft/java/logging/idea/WitchcraftLogFormatFilterTest.java
+++ b/witchcraft-logging-idea/src/test/java/com/palantir/witchcraft/java/logging/idea/WitchcraftLogFormatFilterTest.java
@@ -39,6 +39,10 @@ public final class WitchcraftLogFormatFilterTest {
             + "\"time\":\"2019-05-09T15:32:37.692Z\",\"origin\":\"ROOT\","
             + "\"thread\":\"main\",\"message\":\"test good {}\","
             + "\"params\":{\"good\":\":-)\"},\"unsafeParams\":{},\"tags\":{}}";
+    private static final String SERVICE_JSON_WITH_UNKNOWN_FIELD = "{\"type\":\"service.1\",\"level\":\"ERROR\","
+            + "\"time\":\"2019-05-09T15:32:37.692Z\",\"origin\":\"ROOT\","
+            + "\"thread\":\"main\",\"message\":\"test good {}\","
+            + "\"params\":{\"good\":\":-)\"},\"unsafeParams\":{},\"unknownField\":\"value\"}";
     private static final String SERVICE_FORMATTED =
             "ERROR [2019-05-09T15:32:37.692Z] [main] ROOT: test good {} (good: :-))";
 
@@ -100,6 +104,11 @@ public final class WitchcraftLogFormatFilterTest {
     @Test
     public void formatServiceLine() {
         assertThat(runFilter(SERVICE_JSON)).isEqualTo(SERVICE_FORMATTED);
+    }
+
+    @Test
+    public void formatServiceLineWithUnknownField() {
+        assertThat(runFilter(SERVICE_JSON_WITH_UNKNOWN_FIELD)).isEqualTo(SERVICE_FORMATTED);
     }
 
     @Test


### PR DESCRIPTION
Intellij plugin formats objects which include unknown fields. Previously
new fields added to existing types resulted in raw json console lines.

The https://github.com/palantir/witchcraft-api/pull/313 commit was
missed when this project was split out of witchcraft-api.

==COMMIT_MSG==
Intellij plugin formats objects which include unknown fields. Previously new fields added to existing types resulted in raw json console lines.
==COMMIT_MSG==
