### PR TITLE
Fix #38: The jetbrains plugin no longer leaves errant newlines when lines are filtered

### DIFF
--- a/changelog/@unreleased/pr-39.v2.yml
+++ b/changelog/@unreleased/pr-39.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: The jetbrains plugin no longer leaves errant newlines when lines are
+    filtered
+  links:
+  - https://github.com/palantir/witchcraft-java-logging/pull/39

--- a/witchcraft-logging-idea/src/main/java/com/palantir/witchcraft/java/logging/idea/WitchcraftConsoleViewContentTypes.java
+++ b/witchcraft-logging-idea/src/main/java/com/palantir/witchcraft/java/logging/idea/WitchcraftConsoleViewContentTypes.java
@@ -18,7 +18,6 @@ package com.palantir.witchcraft.java.logging.idea;
 
 import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.openapi.editor.colors.TextAttributesKey;
-import com.intellij.openapi.util.Pair;
 import com.palantir.witchcraft.api.logging.LogLevel;
 import java.util.Map;
 
@@ -48,10 +47,6 @@ final class WitchcraftConsoleViewContentTypes {
             createViewType("WITCHCRAFT_REQUEST", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
     static final ConsoleViewContentType TRACE_TYPE =
             createViewType("WITCHCRAFT_TRACE", ConsoleViewContentType.LOG_EXPIRED_ENTRY);
-    // Marker content type for newlines applied by the formatter
-    static final ConsoleViewContentType NEWLINE_TYPE =
-            createViewType("WITCHCRAFT_NEWLINE", ConsoleViewContentType.LOG_VERBOSE_OUTPUT_KEY);
-    static final Pair<String, ConsoleViewContentType> NEWLINE = Pair.create("\n", NEWLINE_TYPE);
 
     private WitchcraftConsoleViewContentTypes() {}
 

--- a/witchcraft-logging-idea/src/main/java/com/palantir/witchcraft/java/logging/idea/WitchcraftLogFilter.java
+++ b/witchcraft-logging-idea/src/main/java/com/palantir/witchcraft/java/logging/idea/WitchcraftLogFilter.java
@@ -55,6 +55,8 @@ final class WitchcraftLogFilter implements InputFilter, DumbAware {
     @Override
     public List<Pair<String, ConsoleViewContentType>> applyFilter(
             @NotNull String text, @NotNull ConsoleViewContentType contentType) {
+        // Must check if the text is a newline and newlines must be skipped prior to delegation. The
+        // formatter skips non-witchcraft lines (newline text) so it's important to pre-validate.
         if (removeNextLineIfNewline) {
             removeNextLineIfNewline = false;
             if ("\n".equals(text)) {

--- a/witchcraft-logging-idea/src/main/java/com/palantir/witchcraft/java/logging/idea/WitchcraftLogFilter.java
+++ b/witchcraft-logging-idea/src/main/java/com/palantir/witchcraft/java/logging/idea/WitchcraftLogFilter.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.intellij.execution.filters.InputFilter;
 import com.intellij.execution.ui.ConsoleViewContentType;
+import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.util.Pair;
 import java.util.List;
 import java.util.function.BooleanSupplier;
@@ -27,10 +28,15 @@ import java.util.function.Supplier;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-final class WitchcraftLogFilter implements InputFilter {
+final class WitchcraftLogFilter implements InputFilter, DumbAware {
 
     private final InputFilter delegate;
     private final ImmutableMap<ConsoleViewContentType, BooleanSupplier> displayFilter;
+
+    // When multiple lines are returned, the result may include a Pair representing a newline after a parsed
+    // Witchcraft line. If we filter an event, we must also filter the trailing newline character.
+    // An instance of each filter is created for every console, so this may be stateful.
+    private boolean removeNextLineIfNewline = false;
 
     WitchcraftLogFilter(InputFilter delegate, Supplier<WitchcraftLogSettings> settings) {
         this.delegate = delegate;
@@ -49,19 +55,22 @@ final class WitchcraftLogFilter implements InputFilter {
     @Override
     public List<Pair<String, ConsoleViewContentType>> applyFilter(
             @NotNull String text, @NotNull ConsoleViewContentType contentType) {
+        if (removeNextLineIfNewline) {
+            removeNextLineIfNewline = false;
+            if ("\n".equals(text)) {
+                return ImmutableList.of();
+            }
+        }
         List<Pair<String, ConsoleViewContentType>> delegateResult = delegate.applyFilter(text, contentType);
         if (delegateResult == null || !containsWitchcraftData(delegateResult)) {
             return delegateResult;
         }
-        // When multiple lines are returned, the result may include a Pair representing a newline after a parsed
-        // Witchcraft line. If we filter an event, we must also filter the trailing newline character.
-        boolean removeNextLineIfNewline = false;
         ImmutableList.Builder<Pair<String, ConsoleViewContentType>> result =
                 ImmutableList.builderWithExpectedSize(delegateResult.size());
         for (Pair<String, ConsoleViewContentType> item : delegateResult) {
             if (removeNextLineIfNewline) {
                 removeNextLineIfNewline = false;
-                if (WitchcraftConsoleViewContentTypes.NEWLINE.equals(item)) {
+                if ("\n".equals(item.getFirst())) {
                     continue;
                 }
             }

--- a/witchcraft-logging-idea/src/main/java/com/palantir/witchcraft/java/logging/idea/WitchcraftLogFormatFilterProvider.java
+++ b/witchcraft-logging-idea/src/main/java/com/palantir/witchcraft/java/logging/idea/WitchcraftLogFormatFilterProvider.java
@@ -18,11 +18,12 @@ package com.palantir.witchcraft.java.logging.idea;
 
 import com.intellij.execution.filters.ConsoleInputFilterProvider;
 import com.intellij.execution.filters.InputFilter;
+import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 
 /** Intellij plugin implementation. */
-public final class WitchcraftLogFormatFilterProvider implements ConsoleInputFilterProvider {
+public final class WitchcraftLogFormatFilterProvider implements ConsoleInputFilterProvider, DumbAware {
     @NotNull
     @Override
     public InputFilter[] getDefaultFilters(@NotNull Project project) {

--- a/witchcraft-logging-idea/src/main/java/com/palantir/witchcraft/java/logging/idea/WitchcraftLogFormatter.java
+++ b/witchcraft-logging-idea/src/main/java/com/palantir/witchcraft/java/logging/idea/WitchcraftLogFormatter.java
@@ -61,7 +61,7 @@ enum WitchcraftLogFormatter implements InputFilter, DumbAware {
 
             // If this is not the last piece, add a newline
             if (lineIterator.hasNext()) {
-                result.add(WitchcraftConsoleViewContentTypes.NEWLINE);
+                result.add(Pair.createNonNull("\n", contentType));
             }
         }
 

--- a/witchcraft-logging-idea/src/main/java/com/palantir/witchcraft/java/logging/idea/WitchcraftLogFormatter.java
+++ b/witchcraft-logging-idea/src/main/java/com/palantir/witchcraft/java/logging/idea/WitchcraftLogFormatter.java
@@ -20,6 +20,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.intellij.execution.filters.InputFilter;
 import com.intellij.execution.ui.ConsoleViewContentType;
+import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.util.Pair;
 import com.palantir.witchcraft.java.logging.format.LogFormatter;
 import com.palantir.witchcraft.java.logging.format.LogParser;
@@ -27,7 +28,7 @@ import java.util.Iterator;
 import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 
-enum WitchcraftLogFormatter implements InputFilter {
+enum WitchcraftLogFormatter implements InputFilter, DumbAware {
     INSTANCE;
 
     private static final LogParser<Pair<String, ConsoleViewContentType>> LOG_PARSER =


### PR DESCRIPTION
Also added `DumbAware` markers to improve probability the plugin
can live-upgrade while active projects are indexing.

==COMMIT_MSG==
The jetbrains plugin no longer leaves errant newlines when lines are filtered
==COMMIT_MSG==