### PR TITLE
Prototype plugin which prints formatted test output to the console

### DIFF
--- a/gradle-witchcraft-logging/build.gradle
+++ b/gradle-witchcraft-logging/build.gradle
@@ -32,6 +32,10 @@ gradlePlugin {
             id = 'com.palantir.witchcraft-logging-testreport'
             implementationClass = 'com.palantir.witchcraft.java.logging.gradle.testreport.TestReportFormattingPlugin'
         }
+        witchcraftLoggingOutputPlugin {
+            id = 'com.palantir.witchcraft-logging-output'
+            implementationClass = 'com.palantir.witchcraft.java.logging.gradle.output.FormattedOutputPlugin'
+        }
     }
 }
 
@@ -50,6 +54,9 @@ pluginBundle {
         }
         witchcraftLoggingTestReportPlugin {
             displayName = 'Palantir Witchcraft Logging Test Report Rendering Plugin'
+        }
+        witchcraftLoggingOutputPlugin {
+            displayName = 'Palantir Witchcraft Logging Output Rendering Plugin'
         }
     }
 }

--- a/gradle-witchcraft-logging/src/main/groovy/com/palantir/witchcraft/java/logging/gradle/output/FormattedOutputPlugin.java
+++ b/gradle-witchcraft-logging/src/main/groovy/com/palantir/witchcraft/java/logging/gradle/output/FormattedOutputPlugin.java
@@ -1,0 +1,64 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.witchcraft.java.logging.gradle.output;
+
+import com.palantir.witchcraft.java.logging.format.LogFormatter;
+import com.palantir.witchcraft.java.logging.format.LogParser;
+import java.io.PrintStream;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.testing.AbstractTestTask;
+import org.gradle.api.tasks.testing.TestDescriptor;
+import org.gradle.api.tasks.testing.TestOutputEvent.Destination;
+
+public abstract class FormattedOutputPlugin implements Plugin<Project> {
+
+    private static final LogParser<String> PARSER =
+            new LogParser<>(LogFormatter.INSTANCE.combineWith(TestLogFilter.INSTANCE, (formatted, include) -> {
+                if (!include) {
+                    return "";
+                }
+                return formatted + System.lineSeparator();
+            }));
+
+    @Override
+    public final void apply(Project project) {
+        project.getTasks()
+                .withType(AbstractTestTask.class)
+                .configureEach(task -> task.addTestOutputListener((descriptor, event) -> {
+                    PrintStream target = event.getDestination() == Destination.StdErr ? System.err : System.out;
+                    String message = event.getMessage();
+                    String parsedMessage = PARSER.tryParse(message).orElse(message);
+                    if (!parsedMessage.isEmpty()) {
+                        target.printf("[%s] %s", testDescriptor(descriptor), parsedMessage);
+                    }
+                }));
+    }
+
+    private static String testDescriptor(TestDescriptor input) {
+        String className = input.getClassName();
+        if (className == null) {
+            return input.getDisplayName();
+        }
+        int lastIndex = className.lastIndexOf('.');
+        if (lastIndex == className.length() - 1) {
+            return input.getDisplayName();
+        }
+        String abbreviated = lastIndex < 0 ? className : className.substring(lastIndex + 1);
+        return abbreviated + '.' + input.getDisplayName();
+    }
+}

--- a/gradle-witchcraft-logging/src/main/groovy/com/palantir/witchcraft/java/logging/gradle/output/TestLogFilter.java
+++ b/gradle-witchcraft-logging/src/main/groovy/com/palantir/witchcraft/java/logging/gradle/output/TestLogFilter.java
@@ -1,0 +1,53 @@
+/*
+ * (c) Copyright 2021 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.witchcraft.java.logging.gradle.output;
+
+import com.palantir.witchcraft.api.logging.DiagnosticLogV1;
+import com.palantir.witchcraft.api.logging.MetricLogV1;
+import com.palantir.witchcraft.api.logging.TraceLogV1;
+import com.palantir.witchcraft.java.logging.format.LogVisitor;
+import java.util.Optional;
+
+/**
+ * Filtering {@link LogVisitor} implementation with reasonable defaults for tests.
+ */
+enum TestLogFilter implements LogVisitor<Boolean> {
+    INSTANCE;
+
+    private static final Optional<Boolean> ALLOW = Optional.of(Boolean.TRUE);
+    private static final Optional<Boolean> BLOCK = Optional.of(Boolean.FALSE);
+
+    @Override
+    public Optional<Boolean> metricV1(MetricLogV1 _metricLogV1) {
+        return BLOCK;
+    }
+
+    @Override
+    public Optional<Boolean> traceV1(TraceLogV1 _traceLogV1) {
+        return BLOCK;
+    }
+
+    @Override
+    public Optional<Boolean> diagnosticV1(DiagnosticLogV1 _diagnosticLogV1) {
+        return BLOCK;
+    }
+
+    @Override
+    public Optional<Boolean> defaultValue() {
+        return ALLOW;
+    }
+}

--- a/witchcraft-logging-formatting/src/main/java/com/palantir/witchcraft/java/logging/format/LogParser.java
+++ b/witchcraft-logging-formatting/src/main/java/com/palantir/witchcraft/java/logging/format/LogParser.java
@@ -54,7 +54,7 @@ public final class LogParser<T> {
             SERVICE_V1, REQUEST_V2, EVENT_V2, METRIC_V1, TRACE_V1, AUDIT_V2, DIAGNOSTIC_V1, WRAPPED_V1);
 
     private static final String WITCHCRAFT_LOG_PATTERN_STRING = "\\{.*?\"type\"\\s*?:\\s*?\"("
-            + LOG_TYPES.stream().map(Pattern::quote).collect(Collectors.joining("|")) + ")\".*?}";
+            + LOG_TYPES.stream().map(Pattern::quote).collect(Collectors.joining("|")) + ")\".*?}\\R?";
     private static final Pattern WITCHCRAFT_LOG_PATTERN = Pattern.compile(WITCHCRAFT_LOG_PATTERN_STRING);
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()


### PR DESCRIPTION
==COMMIT_MSG==
Prototype plugin which prints formatted test output to the console
==COMMIT_MSG==

Note that this does not play well with:
```groovy
test {
    testLogging {
        showStandardStreams = true
    }
}
```