### PR TITLE
Formatted request log lines include parameters

### DIFF
--- a/changelog/@unreleased/pr-46.v2.yml
+++ b/changelog/@unreleased/pr-46.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Formatted request log lines include parameters
+  links:
+  - https://github.com/palantir/witchcraft-java-logging/pull/46

--- a/witchcraft-logging-formatting/src/main/java/com/palantir/witchcraft/java/logging/format/RequestLogFormatter.java
+++ b/witchcraft-logging-formatting/src/main/java/com/palantir/witchcraft/java/logging/format/RequestLogFormatter.java
@@ -54,7 +54,7 @@ final class RequestLogFormatter {
                     .append(request.getStatus())
                     .append(' ')
                     .append(request.getResponseSize().longValue())
-                    .append(' ')
+                    .append(" bytes ")
                     .append(request.getDuration().longValue())
                     .append(" μs");
 

--- a/witchcraft-logging-formatting/src/test/java/com/palantir/witchcraft/java/logging/format/RequestLogFormatterTest.java
+++ b/witchcraft-logging-formatting/src/test/java/com/palantir/witchcraft/java/logging/format/RequestLogFormatterTest.java
@@ -38,7 +38,7 @@ class RequestLogFormatterTest {
                 .params("param", "value")
                 .build());
 
-        assertThat(formatted).isEqualTo("[2019-12-25T01:02:03Z] \"GET /some/path/value http\" 203 40 99");
+        assertThat(formatted).isEqualTo("[2019-12-25T01:02:03Z] \"GET /some/path/value http\" 203 40 99 μs");
     }
 
     @Test
@@ -56,7 +56,7 @@ class RequestLogFormatterTest {
                 .unsafeParams("path", "/some/path/value")
                 .build());
 
-        assertThat(formatted).isEqualTo("[2019-12-25T01:02:03Z] \"GET /some/path/value http\" 203 40 99");
+        assertThat(formatted).isEqualTo("[2019-12-25T01:02:03Z] \"GET /some/path/value http\" 203 40 99 μs");
     }
 
     @Test
@@ -74,6 +74,8 @@ class RequestLogFormatterTest {
                 .unsafeParams("path", ":witchcraft-logging-formatting")
                 .build());
 
-        assertThat(formatted).isEqualTo("[2019-12-25T01:02:03Z] \"GET /some/path/{unknown} http\" 203 40 99");
+        assertThat(formatted)
+                .isEqualTo("[2019-12-25T01:02:03Z] \"GET /some/path/{unknown} http\" "
+                        + "203 40 99 μs (path: :witchcraft-logging-formatting)");
     }
 }

--- a/witchcraft-logging-formatting/src/test/java/com/palantir/witchcraft/java/logging/format/RequestLogFormatterTest.java
+++ b/witchcraft-logging-formatting/src/test/java/com/palantir/witchcraft/java/logging/format/RequestLogFormatterTest.java
@@ -38,7 +38,7 @@ class RequestLogFormatterTest {
                 .params("param", "value")
                 .build());
 
-        assertThat(formatted).isEqualTo("[2019-12-25T01:02:03Z] \"GET /some/path/value http\" 203 40 99 μs");
+        assertThat(formatted).isEqualTo("[2019-12-25T01:02:03Z] \"GET /some/path/value http\" 203 40 bytes 99 μs");
     }
 
     @Test
@@ -56,7 +56,7 @@ class RequestLogFormatterTest {
                 .unsafeParams("path", "/some/path/value")
                 .build());
 
-        assertThat(formatted).isEqualTo("[2019-12-25T01:02:03Z] \"GET /some/path/value http\" 203 40 99 μs");
+        assertThat(formatted).isEqualTo("[2019-12-25T01:02:03Z] \"GET /some/path/value http\" 203 40 bytes 99 μs");
     }
 
     @Test
@@ -76,6 +76,6 @@ class RequestLogFormatterTest {
 
         assertThat(formatted)
                 .isEqualTo("[2019-12-25T01:02:03Z] \"GET /some/path/{unknown} http\" "
-                        + "203 40 99 μs (path: :witchcraft-logging-formatting)");
+                        + "203 40 bytes 99 μs (path: :witchcraft-logging-formatting)");
     }
 }

--- a/witchcraft-logging-idea/src/test/java/com/palantir/witchcraft/java/logging/idea/WitchcraftLogFormatFilterTest.java
+++ b/witchcraft-logging-idea/src/test/java/com/palantir/witchcraft/java/logging/idea/WitchcraftLogFormatFilterTest.java
@@ -54,7 +54,7 @@ public final class WitchcraftLogFormatFilterTest {
             + "\"traceId\":\"ba3200b6eb01999a\",\"unsafeParams\":{\"path\":\"/api/sleep/10\","
             + "\"millis\":\"10\"}}";
     private static final String REQUEST_FORMATTED =
-            "[2019-05-24T16:40:36.703Z] \"GET /api/sleep/10 HTTP/1.1\" 503 78 1935 μs (host: localhost:8443, "
+            "[2019-05-24T16:40:36.703Z] \"GET /api/sleep/10 HTTP/1.1\" 503 78 bytes 1935 μs (host: localhost:8443, "
                     + "connection: Keep-Alive, accept-encoding: gzip, user-agent: okhttp/3.13.1)";
 
     private static final String METRIC_JSON = "{\"type\": \"metric.1\","

--- a/witchcraft-logging-idea/src/test/java/com/palantir/witchcraft/java/logging/idea/WitchcraftLogFormatFilterTest.java
+++ b/witchcraft-logging-idea/src/test/java/com/palantir/witchcraft/java/logging/idea/WitchcraftLogFormatFilterTest.java
@@ -54,7 +54,8 @@ public final class WitchcraftLogFormatFilterTest {
             + "\"traceId\":\"ba3200b6eb01999a\",\"unsafeParams\":{\"path\":\"/api/sleep/10\","
             + "\"millis\":\"10\"}}";
     private static final String REQUEST_FORMATTED =
-            "[2019-05-24T16:40:36.703Z] \"GET /api/sleep/10 HTTP/1.1\" " + "503 78 1935";
+            "[2019-05-24T16:40:36.703Z] \"GET /api/sleep/10 HTTP/1.1\" 503 78 1935 μs (host: localhost:8443, "
+                    + "connection: Keep-Alive, accept-encoding: gzip, user-agent: okhttp/3.13.1)";
 
     private static final String METRIC_JSON = "{\"type\": \"metric.1\","
             + "\"time\":\"2019-05-24T16:40:52.162Z\","


### PR DESCRIPTION
These parameters are often fairly important, for example the
userAgent and any `safe` marked component in conjure definitions.

==COMMIT_MSG==
Formatted request log lines include parameters
==COMMIT_MSG==

## Possible downsides?
Request log lines may be longer
