### PR TITLE
Fix for Gradle 8.8

### DIFF
--- a/changelog/@unreleased/pr-479.v2.yml
+++ b/changelog/@unreleased/pr-479.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Fix for Gradle 8.8 (would have `NoSuchMethodError` for `DefaultTestReport.<init>`)
+  links:
+  - https://github.com/palantir/witchcraft-java-logging/pull/479

--- a/gradle-witchcraft-logging/build.gradle
+++ b/gradle-witchcraft-logging/build.gradle
@@ -45,3 +45,7 @@ pluginBundle {
     description = 'Palantir Witchcraft logging plugins used to improve developer experience building, running, and debugging applications using the witchcraft logging api: https://github.com/palantir/witchcraft-api.'
     tags = ['witchcraft', 'logging', 'idea']
 }
+
+test {
+    systemProperty 'ignoreDeprecations', 'true'
+}

--- a/gradle-witchcraft-logging/src/test/groovy/com/palantir/witchcraft/java/logging/gradle/testreport/TestReportFormattingPluginIntegrationSpec.groovy
+++ b/gradle-witchcraft-logging/src/test/groovy/com/palantir/witchcraft/java/logging/gradle/testreport/TestReportFormattingPluginIntegrationSpec.groovy
@@ -20,8 +20,11 @@ package com.palantir.witchcraft.java.logging.gradle.testreport
 import nebula.test.IntegrationSpec
 
 class TestReportFormattingPluginIntegrationSpec extends IntegrationSpec {
+    private static final List<String> GRADLE_VERSIONS = ["7.6.4", "8.8"]
 
-    def 'Formats test report stdout and stderr'() {
+    def '#gradleVersionNumber: Formats test report stdout and stderr'() {
+        gradleVersion = gradleVersionNumber
+
         when:
         buildFile << """
         apply plugin: 'java'
@@ -98,5 +101,8 @@ class TestReportFormattingPluginIntegrationSpec extends IntegrationSpec {
         // metric logging should be filtered out entirely
         !htmlReport.contains('Scavenge')
         htmlReport.contains('==Done==')
+
+        where:
+        gradleVersionNumber << GRADLE_VERSIONS
     }
 }


### PR DESCRIPTION
## Before this PR
This plugin fails to work in Gradle 8.8, with the error:

```
Caused by: java.lang.NoSuchMethodError: 'void org.gradle.api.internal.tasks.testing.report.DefaultTestReport.<init>(org.gradle.internal.operations.BuildOperationExecutor)'
	at com.palantir.witchcraft.java.logging.gradle.testreport.TestReportFormattingPlugin.lambda$apply$0(TestReportFormattingPlugin.java:47)
	at org.gradle.internal.code.DefaultUserCodeApplicationContext$CurrentApplication$1.execute(DefaultUserCodeApplicationContext.java:123)
```

This plugin does heinous reflection of Gradle internal classes. In 8.8, they [changed the constructor we reflectively access](https://github.com/gradle/gradle/commit/7e3334ea9d32bf8b4930637c66ece2d08282fe05#diff-a3a2553da64f967f904c1b9c403223dd15ba5acd6e3562333ac7e5af78097c63L48-R50), meaning we get the `NoSuchMethodError` for the one we were trying to use.

## After this PR
Either use the new or old constructor depending on the Gradle version.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
