### PR TITLE
bump intellij plugin to latest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:3.1.0'
         classpath 'com.palantir.javaformat:gradle-palantir-java-format:2.47.0'
         classpath 'gradle.plugin.org.inferred:gradle-processors:3.7.0'
-        classpath 'org.jetbrains.intellij.plugins:gradle-intellij-plugin:1.1.4'
+        classpath 'org.jetbrains.intellij.plugins:gradle-intellij-plugin:1.17.4'
     }
 }
 


### PR DESCRIPTION
needed to work with gradle8

## Before this PR
old intellij plugin will not load under gradle8

## After this PR
==COMMIT_MSG==
<!-- User-facing outcomes this PR delivers -->
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
