### PR TITLE
Use com.palantir.external-publish-intellij for idea plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         classpath 'com.palantir.jakartapackagealignment:jakarta-package-alignment:0.6.0'
         classpath 'com.palantir.gradle.jdks:gradle-jdks:0.46.0'
         classpath 'com.palantir.gradle.jdkslatest:gradle-jdks-latest:0.15.0'
-        classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.17.0'
+        classpath 'com.palantir.gradle.externalpublish:gradle-external-publish-plugin:1.18.0'
         classpath 'com.gradle.publish:plugin-publish-plugin:1.2.2'
         classpath 'com.palantir.baseline:gradle-baseline-java:5.65.0'
         classpath 'com.palantir.gradle.conjure:gradle-conjure:5.50.0'
@@ -17,7 +17,6 @@ buildscript {
         classpath 'com.palantir.gradle.gitversion:gradle-git-version:3.1.0'
         classpath 'com.palantir.javaformat:gradle-palantir-java-format:2.50.0'
         classpath 'gradle.plugin.org.inferred:gradle-processors:3.7.0'
-        classpath 'org.jetbrains.intellij.plugins:gradle-intellij-plugin:1.1.4'
     }
 }
 

--- a/changelog/@unreleased/pr-507.v2.yml
+++ b/changelog/@unreleased/pr-507.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Use com.palantir.external-publish-intellij for idea plugins
+  links:
+  - https://github.com/palantir/witchcraft-java-logging/pull/507

--- a/witchcraft-logging-idea/build.gradle
+++ b/witchcraft-logging-idea/build.gradle
@@ -38,7 +38,7 @@ runPluginVerifier {
             // Idea Ultimate
             "IU-2024.2.1",
             // Goland
-            "GO-2021.2"
+            "GO-2024.2"
             ]
 }
 

--- a/witchcraft-logging-idea/build.gradle
+++ b/witchcraft-logging-idea/build.gradle
@@ -1,7 +1,4 @@
-apply plugin: 'maven-publish'
-apply plugin: 'org.jetbrains.intellij'
-apply plugin: 'com.palantir.external-publish-jar'
-
+apply plugin: 'com.palantir.external-publish-intellij'
 
 dependencies {
     implementation project(':witchcraft-logging-formatting'), {
@@ -23,16 +20,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core'
 }
 
-versionRecommendations {
-    excludeConfigurations 'idea'
-}
-
-versionsLock {
-    // 'org.jetbrains.intellij' creates a dependency on *IntelliJ*, which GCV cannot resolve
-    disableJavaPluginDefaults()
-}
-
-def minimumIntellijBuild = '203.6682.168' // 2020.3.1
+def minimumIntellijBuild = '211.7628.21' // 2021.1
 intellij {
     pluginName = 'witchcraft-logging-idea'
     version = minimumIntellijBuild
@@ -40,34 +28,18 @@ intellij {
 }
 
 patchPluginXml {
-    version = project.version
     sinceBuild = minimumIntellijBuild
-}
-
-publishPlugin {
-    token = System.env.JETBRAINS_PLUGIN_REPO_TOKEN
 }
 
 runPluginVerifier {
     ideVersions = [
             // Idea Community
-            "IC-2021.2",
+            "IC-2024.1",
             // Idea Ultimate
-            "IU-2020.3.1",
+            "IU-2024.2.1",
             // Goland
-            "GO-2021.2"]
+            "GO-2021.2"
+            ]
 }
 
-check.dependsOn buildPlugin, verifyPlugin, runPluginVerifier
-tasks.publishPlugin.onlyIf { versionDetails().isCleanTag && System.env.JETBRAINS_PLUGIN_REPO_TOKEN != null }
-tasks.publish.dependsOn publishPlugin
-buildSearchableOptions.enabled = false
-// Prevent nebula.maven-publish from trying to publish components.java - we are publishing our own different artifact
-ext."nebulaPublish.maven.jar" = false
-publishing {
-    publications {
-        nebula(MavenPublication) {
-            artifact buildPlugin
-        }
-    }
-}
+check.dependsOn runPluginVerifier


### PR DESCRIPTION
## Before this PR
Had the same copy and pasted block of code for publishing intellij plugins which was not centrally managed

## After this PR
Migrated to the `com.palantir.external-publish-intellij` plugin to handle the publication of intellij plugins
