### PR TITLE
require restart and project configurable not using default project

### DIFF
--- a/changelog/@unreleased/pr-610.v2.yml
+++ b/changelog/@unreleased/pr-610.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: require restart and project configurable not using default project
+  links:
+  - https://github.com/palantir/witchcraft-java-logging/pull/610

--- a/witchcraft-logging-idea/src/main/resources/META-INF/plugin.xml
+++ b/witchcraft-logging-idea/src/main/resources/META-INF/plugin.xml
@@ -1,4 +1,4 @@
-<idea-plugin url="https://github.com/palantir/witchcraft-java-logging">
+<idea-plugin url="https://github.com/palantir/witchcraft-java-logging" require-restart="true">
     <id>com.palantir.witchcraft.api.logging.idea</id>
     <name>Witchcraft Logging</name>
     <description>Automatically renders witchcraft-logging-api structured log events from the idea console into color-coded human-readable text.</description>
@@ -9,7 +9,8 @@
         <projectConfigurable id="com.palantir.witchcraft.java.logging.idea.WitchcraftLogSettingsPanel"
                              instance="com.palantir.witchcraft.java.logging.idea.WitchcraftLogSettingsPanel"
                              groupId="build"
-                             displayName="Witchcraft Log Display"/>
+                             displayName="Witchcraft Log Display"
+                             nonDefaultProject="true"/>
         <projectService serviceInterface="com.palantir.witchcraft.java.logging.idea.WitchcraftLogSettingsManager"
                         serviceImplementation="com.palantir.witchcraft.java.logging.idea.WitchcraftLogSettingsManagerImpl"/>
         <additionalTextAttributes scheme="Default" file="colorSchemes/WitchcraftLoggingDefault.xml"/>


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

Currently the witchcraft intellij plugin is not labeled as requires-restart, this means intellji will attempt a dynamic unload of the plugin. For the new [plugin updater](https://github.com/palantir/palantir-idea-plugin-updater) we need plugins to be correctly labeled.

This plugin has 2 issues causing it to not be dynamic:
1. Project configurable with `default project`
2. Input filter being held in by `InputFilterWrapper`

The first issue is easily solvable, but the second issue seems to be an intellij limitation see below:
```
2025-03-14 10:26:38,247 [  32167]   INFO - #c.i.i.p.DynamicPlugins - Snapshot analysis result: Root 1:
  ROOT: Global JNI.
  com.intellij.util.lang.PathClassLoader.(root):
  java.util.ArrayList.classes:
  java.lang.Object[].elementData:
  java.lang.Class.[]:
  com.intellij.openapi.util.ObjectTree.annotationType:
  it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap.myObject2ParentNode:
  java.lang.Object[].key:
  com.intellij.execution.impl.ConsoleViewImpl.[]:
  com.intellij.execution.filters.CompositeInputFilter.myInputMessageFilter:
  com.intellij.execution.filters.CompositeInputFilter$InputFilterWrapper[].myFilters:
  com.intellij.execution.filters.CompositeInputFilter$InputFilterWrapper.[]:
  com.palantir.witchcraft.java.logging.idea.WitchcraftLogFilter.myOriginal:
  java.lang.Class.<class>:
* com.intellij.ide.plugins.cl.PluginClassLoader.annotationType:
```

I have tried making `WitchcraftLogFilter` disposable but that did not prevent the issue it seems that `InputFilterWrapper` creates a strong reference to the filter that is not cleaned up when the plugin is unloaded

## After this PR

Now label plugin as restart-required and fix the project configurable issue

==COMMIT_MSG==
require restart and project configurable not using default project
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

Now restart is require in all situation - this plugin used to be dynamic if no project was open and now it will always require restart
