### PR TITLE
bump `gradle-idea-configuration` and move off deprecated methods

### DIFF
--- a/changelog/@unreleased/pr-661.v2.yml
+++ b/changelog/@unreleased/pr-661.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: bump `gradle-idea-configuration` and move off deprecated methods
+  links:
+  - https://github.com/palantir/witchcraft-java-logging/pull/661

--- a/gradle-witchcraft-logging/src/main/groovy/com/palantir/witchcraft/java/logging/gradle/WitchcraftLoggingPlugin.java
+++ b/gradle-witchcraft-logging/src/main/groovy/com/palantir/witchcraft/java/logging/gradle/WitchcraftLoggingPlugin.java
@@ -34,8 +34,9 @@ public final class WitchcraftLoggingPlugin implements Plugin<Project> {
 
         rootProject.getPluginManager().apply(IdeaConfigurationPlugin.class);
         IdeaConfigurationExtension extension = rootProject.getExtensions().getByType(IdeaConfigurationExtension.class);
-        extension.externalDependency("com.palantir.witchcraft.api.logging.idea", "1.6.0");
-
+        extension
+                .getExternalDependencies()
+                .register("com.palantir.witchcraft.api.logging.idea", dep -> dep.atLeastVersion("1.6.0"));
         rootProject.allprojects(project -> project.getPluginManager().apply(TestReportFormattingPlugin.class));
     }
 }

--- a/versions.lock
+++ b/versions.lock
@@ -12,7 +12,7 @@ com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava (1 c
 com.google.j2objc:j2objc-annotations:3.0.0 (1 constraints: 150aeab4)
 com.palantir.conjure.java:conjure-lib:6.1.0 (1 constraints: 2718096d)
 com.palantir.conjure.java.api:errors:2.19.0 (1 constraints: 2410a5a9)
-com.palantir.gradle.idea-configuration:gradle-idea-configuration:0.2.0 (1 constraints: 0405f135)
+com.palantir.gradle.idea-configuration:gradle-idea-configuration:0.3.0 (1 constraints: 0505f435)
 com.palantir.ri:resource-identifier:1.5.0 (1 constraints: ee0f7499)
 com.palantir.safe-logging:preconditions:1.18.0 (3 constraints: ed2dfa87)
 com.palantir.safe-logging:safe-logging:1.18.0 (3 constraints: 54392cb5)

--- a/versions.props
+++ b/versions.props
@@ -10,4 +10,4 @@ org.junit.vintage:* = 5.12.2
 org.mockito:* = 5.17.0
 org.slf4j:* = 1.7.36
 com.netflix.nebula:nebula-test = 10.6.2
-com.palantir.gradle.idea-configuration:gradle-idea-configuration = 0.2.0
+com.palantir.gradle.idea-configuration:gradle-idea-configuration = 0.3.0


### PR DESCRIPTION
## Before this PR
On version `0.2.0`

## After this PR
On version `0.3.0` and not using deprecated `externalDependency` method

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
bump `gradle-idea-configuration` and move off deprecated methods
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->