### PR TITLE
Reduce memory pressure in FormattingTestReporter

### DIFF
--- a/gradle-witchcraft-logging/src/main/groovy/com/palantir/witchcraft/java/logging/gradle/testreport/FormattingTestReporter.java
+++ b/gradle-witchcraft-logging/src/main/groovy/com/palantir/witchcraft/java/logging/gradle/testreport/FormattingTestReporter.java
@@ -18,12 +18,10 @@ package com.palantir.witchcraft.java.logging.gradle.testreport;
 
 // CHECKSTYLE:OFF
 
-import com.google.common.base.Splitter;
 import com.palantir.witchcraft.java.logging.format.LogFormatter;
 import com.palantir.witchcraft.java.logging.format.LogParser;
 import java.io.File;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.io.Writer;
 import org.gradle.api.Action;
 import org.gradle.api.internal.tasks.testing.junit.result.TestClassResult;
@@ -73,23 +71,56 @@ final class FormattingTestReporter implements TestReporter {
         public void writeAllOutput(long classId, TestOutputEvent.Destination destination, Writer writer) {
             if (destination == TestOutputEvent.Destination.StdErr
                     || destination == TestOutputEvent.Destination.StdOut) {
-                StringWriter stringWriter = new StringWriter();
-                delegate.writeAllOutput(classId, destination, stringWriter);
-                String contents = stringWriter.toString();
-                Splitter.on('\n').splitToStream(contents).forEachOrdered(line -> {
-                    try {
-                        PARSER.tryParse(line)
-                                .orElseGet(() -> out -> {
-                                    out.write(line);
-                                    out.write("\n");
-                                })
-                                .write(writer);
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                });
+                delegate.writeAllOutput(classId, destination, new LineProcessingWriter(writer, PARSER));
             } else {
                 delegate.writeAllOutput(classId, destination, writer);
+            }
+        }
+
+        private static class LineProcessingWriter extends Writer {
+            private final Writer delegate;
+            private final LogParser<Writable> parser;
+            private final StringBuilder lineBuffer = new StringBuilder();
+
+            LineProcessingWriter(Writer delegate, LogParser<Writable> parser) {
+                this.delegate = delegate;
+                this.parser = parser;
+            }
+
+            @Override
+            public void write(char[] cbuf, int off, int len) throws IOException {
+                for (int i = off; i < off + len; i++) {
+                    char c = cbuf[i];
+                    if (c == '\n') {
+                        processLine();
+                    } else {
+                        lineBuffer.append(c);
+                    }
+                }
+            }
+
+            @Override
+            public void flush() throws IOException {
+                delegate.flush();
+            }
+
+            @Override
+            public void close() throws IOException {
+                if (!lineBuffer.isEmpty()) {
+                    processLine();
+                }
+                delegate.close();
+            }
+
+            private void processLine() throws IOException {
+                String line = lineBuffer.toString();
+                parser.tryParse(line)
+                        .orElseGet(() -> out -> {
+                            out.write(line);
+                            out.write("\n");
+                        })
+                        .write(delegate);
+                lineBuffer.setLength(0);
             }
         }
 

--- a/gradle-witchcraft-logging/src/main/groovy/com/palantir/witchcraft/java/logging/gradle/testreport/FormattingTestReporter.java
+++ b/gradle-witchcraft-logging/src/main/groovy/com/palantir/witchcraft/java/logging/gradle/testreport/FormattingTestReporter.java
@@ -18,6 +18,7 @@ package com.palantir.witchcraft.java.logging.gradle.testreport;
 
 // CHECKSTYLE:OFF
 
+import com.google.common.base.Splitter;
 import com.palantir.witchcraft.java.logging.format.LogFormatter;
 import com.palantir.witchcraft.java.logging.format.LogParser;
 import java.io.File;
@@ -69,14 +70,13 @@ final class FormattingTestReporter implements TestReporter {
         }
 
         @Override
-        @SuppressWarnings("StringSplitter")
         public void writeAllOutput(long classId, TestOutputEvent.Destination destination, Writer writer) {
             if (destination == TestOutputEvent.Destination.StdErr
                     || destination == TestOutputEvent.Destination.StdOut) {
                 StringWriter stringWriter = new StringWriter();
                 delegate.writeAllOutput(classId, destination, stringWriter);
                 String contents = stringWriter.toString();
-                for (String line : contents.split("\n")) {
+                Splitter.on('\n').splitToStream(contents).forEachOrdered(line -> {
                     try {
                         PARSER.tryParse(line)
                                 .orElseGet(() -> out -> {
@@ -87,7 +87,7 @@ final class FormattingTestReporter implements TestReporter {
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
-                }
+                });
             } else {
                 delegate.writeAllOutput(classId, destination, writer);
             }

--- a/gradle-witchcraft-logging/src/main/groovy/com/palantir/witchcraft/java/logging/gradle/testreport/FormattingTestReporter.java
+++ b/gradle-witchcraft-logging/src/main/groovy/com/palantir/witchcraft/java/logging/gradle/testreport/FormattingTestReporter.java
@@ -22,6 +22,7 @@ import com.palantir.witchcraft.java.logging.format.LogFormatter;
 import com.palantir.witchcraft.java.logging.format.LogParser;
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.util.function.BiConsumer;
 import org.gradle.api.Action;
@@ -58,7 +59,7 @@ final class FormattingTestReporter implements TestReporter {
                 (include, formatted) -> include
                         ? writer -> {
                             writer.write(formatted);
-                            writer.write("\n");
+                            writer.write('\n');
                         }
                         : Writable.NOP));
         private static final BiConsumer<String, Writer> LINE_PROCESSOR = (line, outputWriter) -> {
@@ -68,12 +69,12 @@ final class FormattingTestReporter implements TestReporter {
                             try {
                                 out.write(line);
                             } catch (IOException e) {
-                                throw new RuntimeException(e);
+                                throw new UncheckedIOException(e);
                             }
                         })
                         .write(outputWriter);
             } catch (IOException e) {
-                throw new RuntimeException(e);
+                throw new UncheckedIOException(e);
             }
         };
 
@@ -131,7 +132,7 @@ final class FormattingTestReporter implements TestReporter {
             private void processLine() throws IOException {
                 String line = lineBuffer.toString();
                 lineProcessor.accept(line, delegate);
-                delegate.write("\n");
+                delegate.write('\n');
                 lineBuffer.setLength(0);
             }
         }

--- a/gradle-witchcraft-logging/src/main/groovy/com/palantir/witchcraft/java/logging/gradle/testreport/FormattingTestReporter.java
+++ b/gradle-witchcraft-logging/src/main/groovy/com/palantir/witchcraft/java/logging/gradle/testreport/FormattingTestReporter.java
@@ -23,6 +23,7 @@ import com.palantir.witchcraft.java.logging.format.LogParser;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
+import java.util.function.BiConsumer;
 import org.gradle.api.Action;
 import org.gradle.api.internal.tasks.testing.junit.result.TestClassResult;
 import org.gradle.api.internal.tasks.testing.junit.result.TestResultsProvider;
@@ -60,6 +61,21 @@ final class FormattingTestReporter implements TestReporter {
                             writer.write("\n");
                         }
                         : Writable.NOP));
+        private static final BiConsumer<String, Writer> LINE_PROCESSOR = (line, outputWriter) -> {
+            try {
+                PARSER.tryParse(line)
+                        .orElseGet(() -> out -> {
+                            try {
+                                out.write(line);
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        })
+                        .write(outputWriter);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        };
 
         private final TestResultsProvider delegate;
 
@@ -71,7 +87,7 @@ final class FormattingTestReporter implements TestReporter {
         public void writeAllOutput(long classId, TestOutputEvent.Destination destination, Writer writer) {
             if (destination == TestOutputEvent.Destination.StdErr
                     || destination == TestOutputEvent.Destination.StdOut) {
-                delegate.writeAllOutput(classId, destination, new LineProcessingWriter(writer, PARSER));
+                delegate.writeAllOutput(classId, destination, new LineProcessingWriter(writer, LINE_PROCESSOR));
             } else {
                 delegate.writeAllOutput(classId, destination, writer);
             }
@@ -79,22 +95,22 @@ final class FormattingTestReporter implements TestReporter {
 
         private static class LineProcessingWriter extends Writer {
             private final Writer delegate;
-            private final LogParser<Writable> parser;
+            private final BiConsumer<String, Writer> lineProcessor;
             private final StringBuilder lineBuffer = new StringBuilder();
 
-            LineProcessingWriter(Writer delegate, LogParser<Writable> parser) {
+            LineProcessingWriter(Writer delegate, BiConsumer<String, Writer> lineProcessor) {
                 this.delegate = delegate;
-                this.parser = parser;
+                this.lineProcessor = lineProcessor;
             }
 
             @Override
             public void write(char[] cbuf, int off, int len) throws IOException {
                 for (int i = off; i < off + len; i++) {
-                    char c = cbuf[i];
-                    if (c == '\n') {
+                    char ch = cbuf[i];
+                    if (ch == '\n') {
                         processLine();
                     } else {
-                        lineBuffer.append(c);
+                        lineBuffer.append(ch);
                     }
                 }
             }
@@ -114,12 +130,8 @@ final class FormattingTestReporter implements TestReporter {
 
             private void processLine() throws IOException {
                 String line = lineBuffer.toString();
-                parser.tryParse(line)
-                        .orElseGet(() -> out -> {
-                            out.write(line);
-                            out.write("\n");
-                        })
-                        .write(delegate);
+                lineProcessor.accept(line, delegate);
+                delegate.write("\n");
                 lineBuffer.setLength(0);
             }
         }


### PR DESCRIPTION
## Before this PR
I saw OOMs on an internal project that I think were contributed to by the code in this class's `writeAllOutput()` method.  That method holds the output multiple times in memory at once:
1. accumulated into StringWriter
2. flatted into the `String contents` 
3. As an array of substrings, in `contents.split("\n")`

For the OOM I observed, the failed allocation was in this stacktrace:

```
Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
v  ~RuntimeStub::_new_array_nozero_Java 0x0000714dc3c619a7
J 4916 c2 java.lang.String.<init>(Ljava/lang/AbstractStringBuilder;Ljava/lang/Void;)V java.base@21.0.8 (99 bytes) @ 0x0000714dc4360070 [0x0000714dc435fb60+0x0000000000000510]
J 31391 c1 java.lang.StringBuffer.toString()Ljava/lang/String; java.base@21.0.8 (34 bytes) @ 0x0000714dbd95eb34 [0x0000714dbd95e9e0+0x0000000000000154]
J 30067 c1 java.io.StringWriter.toString()Ljava/lang/String; java.base@21.0.8 (8 bytes) @ 0x0000714dbe3750ac [0x0000714dbe375040+0x000000000000006c]
j  com.palantir.witchcraft.java.logging.gradle.testreport.FormattingTestReporter$FormattingTestResultsProvider.writeAllOutput(JLorg/gradle/api/tasks/testing/TestOutputEvent$Destination;Ljava/io/Writer;)V+38
j  org.gradle.api.internal.tasks.testing.report.ClassPageRenderer$2.doExecute(Lorg/gradle/internal/html/SimpleHtmlWriter;)V+39
j  org.gradle.api.internal.tasks.testing.report.ClassPageRenderer$2.doExecute(Ljava/lang/Object;)V+5
j  org.gradle.internal.ErroringAction.execute(Ljava/lang/Object;)V+2
j  org.gradle.api.internal.tasks.testing.report.PageRenderer$1.render(Lorg/gradle/api/internal/tasks/testing/report/CompositeTestResults;Lorg/gradle/internal/html/SimpleHtmlWriter;)V+5
```

## After this PR
==COMMIT_MSG==
Reduce memory pressure in FormattingTestReporter
==COMMIT_MSG==

This PR refactors the FormattingTestReporter to hold the contents in memory fewer times. Instead of accumulating all the lines into one `StringWriter stringWriter`, we accumulate characters until we find a newline. Then process that line and continue. And instead of writing the line into an intermedia String and then that String into the delegate, we write directly into the delegate.

## Possible downsides?
- by working at the character level and checking for newlines char by char, we lose batching and mechanical sympathy
- there is existing test coverage in `TestReportFormattingPluginIntegrationSpec` that verifies the results, but there isn't test coverage for performance, which may have regressed. And this PR doesn't currently include test coverage asserting that large amounts of console output can now be processed even with small heaps (difficult to add tests for)